### PR TITLE
Implement custom filename parameter to reference later

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ pandoc tests/sample.md -o sample.pdf --filter pandoc-plantuml
 The PlantUML binary must be in your `$PATH` or can be set with the
 `PLANTUML_BIN` environment variable.
 
+### Additional parameters
+
+You could pass additional parameters into `plantuml` filter which will be processed as picture's options:
+
+````
+```{ .plantuml height=50% plantuml-filename=test.png }
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+```
+````
+
+The `plantuml-filename` parameter create a symlink for the destination picture, which could be used in the same file as an image directly.
+
 ## But there is ...
 
 There are a few other filters trying to convert PlantUML code blocks however

--- a/pandoc_plantuml_filter.py
+++ b/pandoc_plantuml_filter.py
@@ -29,6 +29,7 @@ def plantuml(key, value, format_, _):
             src = filename + '.uml'
             dest = filename + '.' + filetype
 
+            # Generate image only once
             if not os.path.isfile(dest):
                 txt = code.encode(sys.getfilesystemencoding())
                 if not txt.startswith(b"@start"):
@@ -36,8 +37,20 @@ def plantuml(key, value, format_, _):
                 with open(src, "wb") as f:
                     f.write(txt)
 
-                subprocess.check_call(PLANTUML_BIN.split() + ["-t" + filetype, src])
+                subprocess.check_call(PLANTUML_BIN.split() +
+                                      ["-t" + filetype, src])
                 sys.stderr.write('Created image ' + dest + '\n')
+
+            # Update symlink each run
+            for ind, keyval in enumerate(keyvals):
+                if keyval[0] == 'plantuml-filename':
+                    link = keyval[1]
+                    keyvals.pop(ind)
+                    if os.path.islink(link):
+                        os.remove(link)
+
+                    os.symlink(dest, link)
+                    dest = link
 
             return Para([Image([ident, [], keyvals], caption, [dest, typef])])
 

--- a/tests/sample.md
+++ b/tests/sample.md
@@ -9,3 +9,13 @@ Alice <-- Bob: another authentication Response
 ```
 
 Nice, huh?
+
+# Another example which referenced later
+```{ .plantuml width=60% plantuml-filename=example.png }
+[producer] -> [consumer]: data streaming
+```
+
+Here's a UML
+
+# Reference
+![And here's the reference](example.png)


### PR DESCRIPTION
Now it's impossible to create a file and use it later in the same presentation. With this patch, you could define the filename, and the filter will update it after each pandoc execution.