### PR TITLE
Fix case when symlink created in CWD

### DIFF
--- a/pandoc_plantuml_filter.py
+++ b/pandoc_plantuml_filter.py
@@ -18,7 +18,7 @@ PLANTUML_BIN = os.environ.get('PLANTUML_BIN', 'plantuml')
 
 def rel_mkdir_symlink(src, dest):
     dest_dir = os.path.dirname(dest)
-    if not os.path.exists(dest_dir):
+    if dest_dir and not os.path.exists(dest_dir):
         os.makedirs(dest_dir)
 
     if os.path.exists(dest):

--- a/tests/sample.md
+++ b/tests/sample.md
@@ -11,7 +11,15 @@ Alice <-- Bob: another authentication Response
 Nice, huh?
 
 # Another example which referenced later
+This tests relative path w/ subdirectory
+
 ```{ .plantuml width=60% plantuml-filename=images/example.png }
+[producer] -> [consumer]: data streaming
+```
+
+This tests relative path w/o subdirectories
+
+```{ .plantuml width=60% plantuml-filename=example.png }
 [producer] -> [consumer]: data streaming
 ```
 


### PR DESCRIPTION
This PR fixes error `FileNotFoundError: [Errno 2] No such file or directory: ''` when plantuml-filename doesn't contain directories